### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,5 +1,8 @@
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/JensKrumsieck/PorphyStruct/security/code-scanning/1](https://github.com/JensKrumsieck/PorphyStruct/security/code-scanning/1)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly define the permissions required for the workflow, adhering to the principle of least privilege. Since the workflow primarily interacts with repository contents (e.g., checking out code), the `contents: read` permission is sufficient.

The `permissions` block should be added at the top level of the workflow file, ensuring it applies to all jobs in the workflow. No additional dependencies or imports are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
